### PR TITLE
Updated to the latest version, also removed empty spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var regexCreator = require('emoji-regex');
 
-var emojiRegex = regexCreator();
+var emojiRegex = emojiRegex();
 
 function emoji_strip (string) {
-  return string.replace(emojiRegex, '');
+    return string.replace(emojiRegex, "").replace(/^\s+|\s+$|\s+(?=\s)/g, "");
 }
 
 module.exports = emoji_strip;


### PR DESCRIPTION
Removed empty spaces after stripping the emojis, to make the text look like it should.

![prstrip](https://user-images.githubusercontent.com/15928925/92480971-8cc4de00-f1dd-11ea-81a8-76ea069b33e0.PNG)
